### PR TITLE
Add ML training from CSV dataset

### DIFF
--- a/AssistantApp/App.xaml.cs
+++ b/AssistantApp/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using AssistantApp.Data;
 using AssistantApp.ViewModels;
 using AssistantApp.Views;
+using AssistantApp.Services;
 
 namespace AssistantApp
 {
@@ -13,7 +14,8 @@ namespace AssistantApp
             base.OnStartup(e);
             string connString = ConfigurationManager.ConnectionStrings["PostgresConnection"].ConnectionString;
             var dbService = new DatabaseService(connString);
-            var viewModel = new SymptomSelectionViewModel(dbService);
+            var mlService = new MLService(dbService);
+            var viewModel = new SymptomSelectionViewModel(dbService, mlService);
             var mainWindow = new SymptomSelectionView { DataContext = viewModel };
             mainWindow.Show();
             viewModel.LoadDataCommand.Execute(null);

--- a/AssistantApp/AssistantApp.csproj
+++ b/AssistantApp/AssistantApp.csproj
@@ -14,4 +14,10 @@
     <PackageReference Include="Npgsql" Version="9.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Data/diagnosis_dataset.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/AssistantApp/Data/diagnosis_dataset.csv
+++ b/AssistantApp/Data/diagnosis_dataset.csv
@@ -1,0 +1,4 @@
+symptom_ids,diagnosis_id
+1;2,1
+2;3,2
+1;3,1


### PR DESCRIPTION
## Summary
- implement dataset-driven training in `MLService`
- expose train/predict commands in `SymptomSelectionViewModel`
- wire up `MLService` in app startup
- include sample dataset and copy to output

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843579b37a0832f9ff78baa33b9b946