### PR TITLE
Fix ML schema mismatch

### DIFF
--- a/AssistantApp/Services/MLService.cs
+++ b/AssistantApp/Services/MLService.cs
@@ -1,6 +1,7 @@
-﻿using AssistantApp.Data;
+using AssistantApp.Data;
 using AssistantApp.Models;
 using Microsoft.ML;
+using Microsoft.ML.Data;
 using System.IO;
 
 namespace AssistantApp.Services
@@ -99,7 +100,10 @@ namespace AssistantApp.Services
                 if (_symptomIndexMap.TryGetValue(id, out var idx))
                     featureVector[idx] = 1f;
             }
-            var engine = _mlContext.Model.CreatePredictionEngine<ModelInput, ModelOutput>(_trainedModel);
+            var schemaDef = SchemaDefinition.Create(typeof(ModelInput));
+            schemaDef[nameof(ModelInput.Features)].ColumnType =
+                new VectorDataViewType(NumberDataViewType.Single, _symptomIndexMap.Count);
+            var engine = _mlContext.Model.CreatePredictionEngine<ModelInput, ModelOutput>(_trainedModel, inputSchemaDefinition: schemaDef);
             var input = new ModelInput { Features = featureVector };
             var output = engine.Predict(input);
             return output.PredictedLabel;


### PR DESCRIPTION
## Summary
- fix `PredictDiagnosisAsync` schema definition
- remove BOM from MLService.cs

## Testing
- `dotnet build AssistantApp.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435a1d923c832f8495fb54f61d3fe0