### PR TITLE
Add radio buttons for diagnosis input mode

### DIFF
--- a/AssistantApp/MainWindow.xaml
+++ b/AssistantApp/MainWindow.xaml
@@ -46,8 +46,12 @@
                             </Grid.ColumnDefinitions>
                             <Border Background="{StaticResource PanelBackground}" CornerRadius="8" Padding="12">
                                 <StackPanel>
+                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                                        <RadioButton Content="Выбор из списка" GroupName="InputMode" IsChecked="{Binding IsListMode, Mode=TwoWay}"/>
+                                        <RadioButton Content="Свободный ввод" GroupName="InputMode" Margin="10,0,0,0" IsChecked="{Binding IsTextMode, Mode=TwoWay}"/>
+                                    </StackPanel>
                                     <TextBlock Text="Выберите симптомы" FontSize="18" Foreground="{StaticResource AccentBrush}"/>
-                                    <TreeView ItemsSource="{Binding Categories}" Margin="0,10,0,0">
+                                    <TreeView ItemsSource="{Binding Categories}" Margin="0,10,0,0" IsEnabled="{Binding IsListMode}">
                                         <TreeView.ItemTemplate>
                                             <HierarchicalDataTemplate ItemsSource="{Binding Symptoms}">
                                                 <TextBlock>
@@ -84,11 +88,11 @@
                                     </TreeView>
                                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                                         <TextBlock Text="Интенсивность боли:" VerticalAlignment="Center"/>
-                                        <Slider Minimum="0" Maximum="10" Value="5" Width="150" Margin="10,0,0,0"/>
+                                        <Slider Minimum="0" Maximum="10" Value="5" Width="150" Margin="10,0,0,0" IsEnabled="{Binding IsListMode}"/>
                                     </StackPanel>
-                                    <StackPanel Margin="0,10,0,0">
+                                    <StackPanel Margin="0,10,0,0" IsEnabled="{Binding IsTextMode}">
                                         <TextBlock Text="Свободный ввод жалоб" FontSize="18" Foreground="{StaticResource AccentBrush}"/>
-                                        <TextBox Height="60" TextWrapping="Wrap" Margin="0,6,0,0"/>
+                                        <TextBox Height="60" TextWrapping="Wrap" Margin="0,6,0,0" Text="{Binding ComplaintText, UpdateSourceTrigger=PropertyChanged}"/>
                                     </StackPanel>
                                     <Button Content="Предсказать" Margin="0,20,0,0" Command="{Binding PredictCommand}"/>
                                 </StackPanel>


### PR DESCRIPTION
## Summary
- allow choosing between list-based or free-text symptom entry via radio buttons
- disable unused controls based on selected mode
- parse free-text complaints and map them to symptom selections

## Testing
- `dotnet build AssistantApp.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684832670998832fa37fbd9a40a7e3ea